### PR TITLE
Enable install_github() : Minor edit of DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -7,7 +7,7 @@ Author: Max Kuhn, Kjell Johnson
 Maintainer: Max Kuhn <mxkuhn@gmail.com>
 Description: A few functions and several data set for the Springer book 'Applied Predictive Modeling'.
 URL: http://appliedpredictivemodeling.com/
-Depends: R (>= 3.1)
+Depends: R (>= 2.10)
 Imports: CORElearn, MASS, plyr, reshape2, lattice, ellipse
 Suggests: caret (>= 6.0-22)
 License: GPL-2

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -7,8 +7,7 @@ Author: Max Kuhn, Kjell Johnson
 Maintainer: Max Kuhn <mxkuhn@gmail.com>
 Description: A few functions and several data set for the Springer book 'Applied Predictive Modeling'.
 URL: http://appliedpredictivemodeling.com/
-Depends:
-    R (>= 3.1)
+Depends: R (>= 3.1)
 Imports: CORElearn, MASS, plyr, reshape2, lattice, ellipse
 Suggests: caret (>= 6.0-22)
 License: GPL-2

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -7,7 +7,8 @@ Author: Max Kuhn, Kjell Johnson
 Maintainer: Max Kuhn <mxkuhn@gmail.com>
 Description: A few functions and several data set for the Springer book 'Applied Predictive Modeling'.
 URL: http://appliedpredictivemodeling.com/
-Depends: R (>= 2.10) 
+Depends:
+    R (>= 3.1)
 Imports: CORElearn, MASS, plyr, reshape2, lattice, ellipse
 Suggests: caret (>= 6.0-22)
 License: GPL-2


### PR DESCRIPTION
Minor edit of DESCRIPTION to enable `devtools::install_github('RickPack/AppliedPredictiveModeling')` to succeed without:
```
Error in FUN(X[[i]], ...) : 
  Invalid comparison operator in dependency: >= 
```
Addresses [issue 1](https://github.com/topepo/AppliedPredictiveModeling/issues/1).